### PR TITLE
Convert phase 0 candidate title strings to ASIN for phase 1

### DIFF
--- a/src/recsys/inference.py
+++ b/src/recsys/inference.py
@@ -5,19 +5,6 @@ from typing import List, Dict, OrderedDict, Tuple
 import numpy as np
 
 
-# Phase 0.5
-def title_to_asin(title: str) -> str:
-    """
-    Convert book title to its corresponding Amazon Standard Identification Number (ASIN).
-    Args:
-        title: Book title
-
-    Returns:
-         Amazon Standard Identification Number (ASIN)
-    """
-    return "<UNKNOWN>"
-
-
 def cosine_similarity(a: List[float], b: List[float]) -> float:
     return np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))
 

--- a/src/spinereader/titleasin.py
+++ b/src/spinereader/titleasin.py
@@ -46,6 +46,7 @@ class TextToAsin:
     def title_to_asin(self, query_strings, k=1) -> str:
         query_embeddings = [self.model.encode([s]) for s in query_strings]
         similar_item_idx = self.return_k_similar(query_embeddings, k)
-        return self.df.iloc[similar_item_idx, ][['asin', 'title']]
+        # df.iloc[similar_item_idx, ][['asin', 'processed_titles']] # look at titles for debugging
+        return df.iloc[similar_item_idx, ]['asin'].tolist()
 
 

--- a/src/spinereader/titleasin.py
+++ b/src/spinereader/titleasin.py
@@ -32,15 +32,15 @@ class TextToAsin:
         self.df = pd.read_csv(title_emb_path).dropna()
     
     def return_k_similar(self, query_embeddings, k=1):
-        top_k_titles = np.array([])
+        top_k_title_idx = np.array([])
         for query in query_embeddings:
             similarity_mat = cosine_similarity(query, self.reference_embeddings)
             similarity_score = similarity_mat[0]
             if k == 1:
-                top_k_titles = np.append(top_k_titles, np.argmax(similarity_score).reshape(1, -1))
+                top_k_title_idx = np.append(top_k_title_idx, np.argmax(similarity_score).reshape(1, -1))
             elif k is not None:
-                top_k_titles = np.append(top_k_titles, np.flip(similarity_score.argsort()[-k:][::1]).reshape(1, -1))
-        return top_k_titles
+                top_k_title_idx = np.append(top_k_title_idx, np.flip(similarity_score.argsort()[-k:][::1]).reshape(1, -1))
+        return top_k_title_idx
     
     # k is number of titles to extract
     def title_to_asin(self, query_strings, k=1) -> str:

--- a/src/spinereader/titleasin.py
+++ b/src/spinereader/titleasin.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from sentence_transformers import SentenceTransformer
+from sklearn.metrics.pairwise import cosine_similarity
+
+TITLE_EMBEDDING_DIRNAME = Path(__file__).resolve().parent / "artifacts"
+TITLE_EMBEDDING_FILE = "title_matching_embeddings.npy"
+
+DATA_DIRNAME = Path(__file__).resolve().parent.parent.parent / "data"
+books_csv_file = "books_emb_8_tidy.csv"
+
+class TextToAsin:
+    """Serves as a bridge between phase 0 and phase 1 by converting detecting text into book ASIN.
+    
+    # example usage:
+    phase_half = TextToAsin()
+    query_strings = ["crime and punishment dostoevsky", "harry potter and the prisoner"]
+    phase_half.title_to_asin(query_strings)
+    """
+
+    def __init__(self, title_emb_path=None, product_emb_path=None):
+        self.model = SentenceTransformer('sentence-transformers/distiluse-base-multilingual-cased-v2')
+        if title_emb_path is None:
+            title_emb_path = TITLE_EMBEDDING_DIRNAME / TITLE_EMBEDDING_FILE
+        self.reference_embeddings = np.load(title_emb_path)
+
+        if product_emb_path is None:
+            title_emb_path = DATA_DIRNAME / books_csv_file
+        self.df = pd.read_csv(title_emb_path).dropna()
+    
+    def return_k_similar(self, query_embeddings, k=1):
+        top_k_titles = np.array([])
+        for query in query_embeddings:
+            similarity_mat = cosine_similarity(query, self.reference_embeddings)
+            similarity_score = similarity_mat[0]
+            if k == 1:
+                top_k_titles = np.append(top_k_titles, np.argmax(similarity_score).reshape(1, -1))
+            elif k is not None:
+                top_k_titles = np.append(top_k_titles, np.flip(similarity_score.argsort()[-k:][::1]).reshape(1, -1))
+        return top_k_titles
+    
+    # k is number of titles to extract
+    def title_to_asin(self, query_strings, k=1) -> str:
+        query_embeddings = [self.model.encode([s]) for s in query_strings]
+        similar_item_idx = self.return_k_similar(query_embeddings, k)
+        return self.df.iloc[similar_item_idx, ][['asin', 'title']]
+
+


### PR DESCRIPTION
# Description

Created class TextToAsin for phase 0.5, which links title predictions from phase 0 to the input format required for recommendations in phase 1. The class has two methods:

1. title_to_asin implements the main functionality of converting candidate title strings to ASINs
2. return_k_similar returns the indices of the top k most similar titles, according to cosine similarity of the BERT embedding

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
