### PR TITLE
Improve segmentation

### DIFF
--- a/src/models/image_segmentation.py
+++ b/src/models/image_segmentation.py
@@ -5,13 +5,21 @@ https://github.com/LakshyaKhatri/Bookshelf-Reader-API
 """
 
 import math
+import os
+from pathlib import Path
 
 import cv2
 import numpy as np
 from PIL import Image
 
+CROPPED_IMAGES_DIRNAME = (
+    Path(__file__).resolve().parent.parent.parent / "cropped_images"
+)
 
-def crop_book_spines_in_image(pil_img, output_img_type: str = "pil"):
+
+def crop_book_spines_in_image(
+    pil_img, output_img_type: str = "pil", save_images: bool = False
+):
     """
     Identifies the book spines in the input image
     and returns list of such book spine images.
@@ -20,7 +28,16 @@ def crop_book_spines_in_image(pil_img, output_img_type: str = "pil"):
     # resizing images to control cropping behavior
     cv2_img = resize_img(cv2_img)
     points = detect_spines(cv2_img)
-    return get_cropped_images(cv2_img, points, output_img_type=output_img_type)
+    cropped_images = get_cropped_images(
+        cv2_img, points, output_img_type=output_img_type
+    )
+    if save_images == True:
+        Path(CROPPED_IMAGES_DIRNAME).mkdir(parents=True, exist_ok=True)
+        for i, img in enumerate(cropped_images):
+            image_to_save_path = f"{CROPPED_IMAGES_DIRNAME}\image_{i}.png"
+            cv2.imwrite(image_to_save_path, pil_image_to_opencv_image(img))
+
+    return cropped_images
 
 
 def detect_spines(img):
@@ -113,7 +130,7 @@ def get_cropped_images(image, points, output_img_type: str = "pil"):
         last_x1 = x1
         last_x2 = x2
 
-    return cropped_images
+    return cropped_images[1:]
 
 
 def get_points_in_x_and_y(hough_lines, max_x, max_y):

--- a/src/models/image_segmentation.py
+++ b/src/models/image_segmentation.py
@@ -17,6 +17,8 @@ def crop_book_spines_in_image(pil_img, output_img_type: str = "pil"):
     and returns list of such book spine images.
     """
     cv2_img = pil_image_to_opencv_image(pil_img)
+    # resizing images to control cropping behavior
+    cv2_img = resize_img(cv2_img)
     points = detect_spines(cv2_img)
     return get_cropped_images(cv2_img, points, output_img_type=output_img_type)
 
@@ -190,6 +192,30 @@ def shorten_line(points, y_max):
         shortened_points.append((start_point, end_point))
 
     return shortened_points
+
+
+def resize_img(img):
+    """
+    Resizes image to a max width or height of 1000px
+    """
+    img = img.copy()
+    img_ht, img_wd, _ = img.shape
+
+    max_lenght = 1000
+
+    if img_wd >= img_ht:
+        ratio = img_wd / img_ht
+        new_width = 1000
+        new_height = math.ceil(new_width / ratio)
+
+    elif img_wd < img_ht:
+        ratio = img_ht / img_wd
+        new_height = 1000
+        new_width = math.ceil(new_height / ratio)
+
+    resized_image = cv2.resize(img, (new_width, new_height))
+
+    return resized_image
 
 
 def pil_image_to_opencv_image(pil_image):


### PR DESCRIPTION
#### Implemented several changes to make the segmentation more robust

The `crop_book_spines_in_image` function now resizes the images before detecting the spines and cropping. This was done to prevent input images of different sizes getting segmented in very different ways. 
Added the option to save the cropped images with `save_images=True`.
Also now the first crop is ignored, as it persistently didn't represent any book cover.

Changed the order of the last steps in the `detect_spines` function. 
Added a `remove_diagonals` to remove lines that are too slanted.
And now the lines are first standardized in terms of height and only then sorted and the duplicates lines removed.


Fixed a bug in the function get_points_in_x_and_y that asumed the width of the image was 500 pixels.

Finally changed the remove_duplicate_lines function to prevent cropped images where its two spine lines intersect each other.
